### PR TITLE
nullproof 追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -5,7 +5,7 @@ AR            = ar
 
 TARGET = ../yges_c.a
 OBJS   = \
-	system/emergency_trap.o \
+	system/emergency_trap.o system/nullproof.o \
 	memory/safe_alloc.o \
 	trash/dummy.o
 

--- a/api/system/emergency_trap.c
+++ b/api/system/emergency_trap.c
@@ -6,6 +6,8 @@
 #include "./emergency_trap.h"
 #include <stdlib.h>
 
+#include "./nullproof.h"
+
 FYgEsExitProc gYgEsExitProc=NULL;
 
 static YgEsEmergencyContext* EmergencyStack=NULL;
@@ -13,7 +15,7 @@ static YgEsEmergencyContext* EmergencyStack=NULL;
 /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
 void yges_register_emergency(YgEsEmergencyContext* src){
 
-	if(!src)return;
+	if(yges_nullproof(src))return;
 
 	// link to EmergencyStack 
 	src->_next=NULL;
@@ -24,7 +26,7 @@ void yges_register_emergency(YgEsEmergencyContext* src){
 /* ----------------------------------------------------------------------- */
 void yges_remove_emergency(YgEsEmergencyContext* src){
 
-	if(!src)return;
+	if(yges_nullproof(src))return;
 
 	YgEsEmergencyContext* prev=NULL;
 	for(YgEsEmergencyContext* ctx=EmergencyStack;ctx;prev=ctx,ctx=ctx->_next){

--- a/api/system/nullproof.c
+++ b/api/system/nullproof.c
@@ -1,0 +1,17 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Nullproof
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./nullproof.h"
+#include "./emergency_trap.h"
+
+const char* YgEsEmergencyCause_Nullpo="Null Pointer Trap";
+int YgEsEmergencyExit_Nullpo=-100;
+
+/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+int yges_null_trap(const char* file,int line){
+
+	int exitcode=yges_happen_emergency(YgEsEmergencyCause_Nullpo,NULL,file,line);
+	return exitcode?exitcode:YgEsEmergencyExit_Nullpo;
+}

--- a/api/system/nullproof.h
+++ b/api/system/nullproof.h
@@ -1,0 +1,55 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Nullproof
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+
+	@pre  define YGES_NULL_TRAP before include this to hook EmergencyTrap
+	@pre  define YGES_NULL_REPORT and indicate function name before include this
+		to report by null detection
+*/
+#ifndef YGES_NULLPROOF_H__
+#define YGES_NULLPROOF_H__
+
+//! call by reporting null detected 
+/*!	@param file  caller source file
+	@param line  caller line of the source file
+	@return  dummy for another return value
+*/
+typedef int (*FYgEsNullReport)(const char* file,int line);
+
+//! emergency cause of null trap 
+extern const char* YgEsEmergencyCause_Nullpo;
+//! exit code of null trap 
+extern int YgEsEmergencyExit_Nullpo;
+
+#if defined(YGES_NULL_REPORT)
+// report by null 
+#define yges_nullproof(p) ((p)?0:1|YGES_NULL_REPORT(__FILE__,__LINE__))
+#elif defined(YGES_NULL_TRAP)
+// trap by null 
+#define yges_nullproof(p) ((p)?0:yges_null_trap(__FILE__,__LINE__))
+#else
+//! null checking 
+/*!	@param p  checking pointer
+	@return  exit code (0 is safe and not exit)
+	@pre  define YGES_NULL_TRAP or YGES_NULL_REPORT before include this or ignored
+*/
+#define yges_nullproof(p) ((p)?0:YgEsEmergencyExit_Nullpo)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! always trap (by null) 
+/*!	@param file  caller source file
+	@param line  caller line of the source file
+	@return  exit code (but not exit)
+*/
+int yges_null_trap(const char* file,int line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // YGES_NULLPROOF_H__

--- a/test/lib/Makefile
+++ b/test/lib/Makefile
@@ -6,7 +6,10 @@ AR            = ar
 TARGET = ../test.a
 INTERMED = test_intermediate.a
 LINKAGES = ../../yges_c.a
-OBJS   = trash/dummy2.o 
+OBJS   = \
+	test_nullproof/test_null_thru.o test_nullproof/test_null_trap.o \
+	test_nullproof/test_null_report.o \
+	trash/dummy2.o 
 
 all: $(TARGET)
 

--- a/test/lib/test_nullproof/test_null_report.c
+++ b/test/lib/test_nullproof/test_null_report.c
@@ -1,0 +1,30 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Reporting
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./test_null_report.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+// to trap by null detection 
+#define YGES_NULL_REPORT null_reporting
+#include "system/nullproof.h"
+
+int Test_NullReported=0;
+
+static int null_reporting(const char* file,int line){
+
+//	printf("null detected in %s:%d\n",file,line);
+
+	++Test_NullReported;
+	return 0;
+}
+
+void test_null_report(void* src){
+
+	if(yges_nullproof(src))return;
+
+	// can access to src, or abend 
+	if(!src)exit(YgEsEmergencyExit_Nullpo);
+}

--- a/test/lib/test_nullproof/test_null_report.h
+++ b/test/lib/test_nullproof/test_null_report.h
@@ -1,0 +1,19 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Reporting
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef TEST_NULL_REPORT_H__
+#define TEST_NULL_REPORT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void test_null_report(void* src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //  TEST_NULL_REPORT_H__

--- a/test/lib/test_nullproof/test_null_thru.c
+++ b/test/lib/test_nullproof/test_null_thru.c
@@ -1,0 +1,19 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Throughing
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./test_null_thru.h"
+#include <stdlib.h>
+
+// including simply 
+// yges_nullproof() checks only  
+#include "system/nullproof.h"
+
+void test_null_thru(void* src){
+
+	if(yges_nullproof(src))return;
+
+	// can access to src, or abend 
+	if(!src)exit(YgEsEmergencyExit_Nullpo);
+}

--- a/test/lib/test_nullproof/test_null_thru.h
+++ b/test/lib/test_nullproof/test_null_thru.h
@@ -1,0 +1,19 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Throughing
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef TEST_NULL_THRU_H__
+#define TEST_NULL_THRU_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void test_null_thru(void* src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //  TEST_NULL_THRU_H__

--- a/test/lib/test_nullproof/test_null_trap.c
+++ b/test/lib/test_nullproof/test_null_trap.c
@@ -1,0 +1,19 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Trapping
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./test_null_trap.h"
+#include <stdlib.h>
+
+// to trap by null detection 
+#define YGES_NULL_TRAP
+#include "system/nullproof.h"
+
+void test_null_trap(void* src){
+
+	if(yges_nullproof(src))return;
+
+	// can access to src, or abend 
+	if(!src)exit(YgEsEmergencyExit_Nullpo);
+}

--- a/test/lib/test_nullproof/test_null_trap.h
+++ b/test/lib/test_nullproof/test_null_trap.h
@@ -1,0 +1,19 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Null Test: Trapping
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef TEST_NULL_TRAP_H__
+#define TEST_NULL_TRAP_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void test_null_trap(void* src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //  TEST_NULL_TRAP_H__

--- a/test/scn/Makefile
+++ b/test/scn/Makefile
@@ -4,7 +4,7 @@ LDFLAGS       = -L/usr/local/lib
 AR            = ar
 
 TARGET = \
-	system/emergency.exe \
+	system/emergency.exe system/nullproof.exe \
 	memory/safe_alloc.exe \
 	test_always.exe trash/test_never.exe 
 

--- a/test/scn/system/nullproof.c
+++ b/test/scn/system/nullproof.c
@@ -1,0 +1,82 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Nullproof Test
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include <stddef.h>
+#include <stdio.h>
+#include "system/emergency_trap.h"
+#include "test_nullproof/test_null_thru.h"
+#include "test_nullproof/test_null_trap.h"
+#include "test_nullproof/test_null_report.h"
+
+// emergency cause of nullproof 
+extern const char* YgEsEmergencyCause_Nullpo;
+// indicate null reporting 
+extern int Test_NullReported;
+
+static int ExitCode_Failure=1;
+
+//! test emergency context 
+static YgEsEmergencyContext TestEmergencyContext;
+
+//! test emergency info 
+typedef struct EmergencyInfo_ EmergencyInfo;
+struct EmergencyInfo_{
+	int Called;
+};
+static EmergencyInfo TestEmergencyInfo;
+
+static int on_emergency(YgEsEmergencyContext* ctx,const char* cause,void* info,const char* file,int line){
+
+	// ignore from other causes 
+	if(cause!=YgEsEmergencyCause_Nullpo)return 0;
+
+	EmergencyInfo* info_c=ctx->User;
+	++info_c->Called;
+
+	return 0;
+}
+
+int main(){
+
+	// emergency settings 
+	TestEmergencyContext.Enabled=true;
+	TestEmergencyContext.Hook=on_emergency;
+	TestEmergencyContext.User=&TestEmergencyInfo;
+	TestEmergencyInfo.Called=0;
+	yges_register_emergency(&TestEmergencyContext);
+
+	// null check only 
+	test_null_thru(NULL);
+	// on_emergency should not called yet 
+	if(TestEmergencyInfo.Called!=0)return ExitCode_Failure;
+	// not reported yet 
+	if(Test_NullReported!=0)return ExitCode_Failure;
+
+	// trap by null detection 
+	test_null_trap(NULL);
+	// on_emergency should called 
+	if(TestEmergencyInfo.Called!=1)return ExitCode_Failure;
+	// not reported yet 
+	if(Test_NullReported!=0)return ExitCode_Failure;
+
+	// not null; should not trap 
+	test_null_trap(&TestEmergencyInfo);
+	// on_emergency should not called now 
+	if(TestEmergencyInfo.Called!=1)return ExitCode_Failure;
+	// not reported yet 
+	if(Test_NullReported!=0)return ExitCode_Failure;
+
+	// report by null detection 
+	test_null_report(NULL);
+	// should reported now 
+	if(Test_NullReported!=1)return ExitCode_Failure;
+
+	// not null; should not report 
+	test_null_report(&TestEmergencyInfo);
+	// not reported now 
+	if(Test_NullReported!=1)return ExitCode_Failure;
+
+	return 0;
+}


### PR DESCRIPTION
close #17 

test/lib/test_nullproof/*.c 参照

ポインタ調査対象のソースファイル毎、 system/nullproof.h のinclude前に動作設定を行う。  
それにより yges_nullproof() の動作が変わる。  

## 設定事項

### 通常

設定なしのときは、単にポインタのnullチェックを行うだけ。  
返値が0のときが正常なので、単純に if(yges_nullproof(ptr))return; とかでもよい。  

### レポート対応

事前に #define YGES_NULL_REPORT ファンクション名 を記述することで、
null検出時に指定ファンクションへソースファイル名と行番号を渡す。  

### エマージェンシートラップ対応

事前に #define YGES_NULL_TRAP を記述することで、null検出時にエマージェンシートラップが発生する。  
(機能詳細は #22 参照)  
YGES_NULL_REPORT とは共存できない。  

## 注意事項

ソースファイル毎に違う設定を反映させるため、includeは調査対象ソースファイルのみから行う。  
共通のヘッダファイル等からのincludeは非推奨とする。  
