### PR TITLE
簡易ファイルローダ追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -8,7 +8,8 @@ TARGET = ../yges_c.a
 OBJS   = \
 	system/emergency_trap.o system/nullproof.o \
 	system/emergency_trap_pp.o \
-	memory/safe_alloc.o
+	memory/safe_alloc.o \
+	file/quick_loader.o file/quick_loader_pp.o
 
 all: $(TARGET)
 	ar r $(TARGET) $(OBJS)

--- a/api/file/quick_loader.c
+++ b/api/file/quick_loader.c
@@ -1,0 +1,49 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./quick_loader.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+YgEsLoaded* yges_load(const char* path,bool shortable){
+
+	YgEsLoaded* inst=NULL;
+	struct stat st;
+	FILE* fp;
+
+	// detect file size 
+	if(stat(path,&st)==-1)return NULL;
+	fp=fopen(path,"rb");
+	if(fp==NULL)return NULL;
+
+	inst=malloc(sizeof(YgEsLoadedHead)+st.st_size+sizeof(YgEsLoadedFoot));
+	if(inst){
+		// try read 
+		inst->filesize=st.st_size;
+		inst->readsize=fread(yges_loaded_bgn(inst),1,inst->filesize,fp);
+	}
+
+	fclose(fp);
+	if(!shortable && inst->readsize<inst->filesize){
+		// reject incompleted load 
+		yges_unload(&inst);
+	}
+	if(!inst)return NULL;
+
+	// cleanup footer and misloaded area
+	memset((char*)yges_loaded_bgn(inst)+inst->readsize,0,inst->filesize-inst->readsize+sizeof(YgEsLoadedFoot));
+	return inst;
+}
+
+/* ----------------------------------------------------------------------- */
+void yges_unload(YgEsLoaded** instp){
+	if(!*instp)return;
+	free(*instp);
+	*instp=NULL;
+}

--- a/api/file/quick_loader.h
+++ b/api/file/quick_loader.h
@@ -1,0 +1,66 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef YGES_QUICK_LOADER_H__
+#define YGES_QUICK_LOADER_H__
+
+#include <stddef.h>
+#include <stdbool.h>
+
+//! Loaded header block 
+typedef struct YgEsLoadedHead_ YgEsLoadedHead;
+//! Loaded footer block 
+typedef struct YgEsLoadedFoot_ YgEsLoadedFoot;
+//! Loaded instance 
+typedef YgEsLoadedHead YgEsLoaded;
+
+struct YgEsLoadedHead_{
+	size_t filesize; //!< file size 
+	size_t readsize; //!< read size 
+};
+
+/*!	@note loaded text file can use as standard C string
+*/
+struct YgEsLoadedFoot_{
+	char zero[8]; //!< fill with zero 
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! load a file 
+/*!	@param path  target file
+	@param shortable  allow incompleted load
+	@return  header pointer of loaded file (or NULL)
+*/
+YgEsLoaded* yges_load(const char* path,bool shortable);
+
+//! free YgEsLoaded file 
+/*!	@param instp  pointer of stored from yges_load()
+	@note  free target memory and instance pointer be NULL
+*/
+void yges_unload(YgEsLoaded** instp);
+
+//! get first pointer of loaded body 
+inline void* yges_loaded_bgn(YgEsLoaded* inst){
+	return inst+1;
+}
+
+//! get terminate pointer of loaded body 
+inline void* yges_loaded_end(YgEsLoaded* inst){
+	return (char*)yges_loaded_bgn(inst)+inst->readsize;
+}
+
+//! get footer pointer of loaded body 
+inline YgEsLoadedFoot* yges_loaded_foot(YgEsLoaded* inst){
+	return (YgEsLoadedFoot*)((char*)yges_loaded_bgn(inst)+inst->filesize);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // YGES_QUICK_LOADER_H__

--- a/api/file/quick_loader.hpp
+++ b/api/file/quick_loader.hpp
@@ -1,0 +1,63 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef YGES_QUICK_LOADER_HPP__
+#define YGES_QUICK_LOADER_HPP__
+
+#include "./quick_loader.h"
+
+namespace yges{
+
+	//! keep a loaded file image 
+	/*!	@note  auto unloading at end of the instance. 
+	*/
+	class FileImage{
+		public:
+		virtual ~FileImage();
+
+		//! load a file 
+		/*!	@param path  target file
+			@param shortable  allow incompleted load
+			@attention  of course, an instance always created.
+				call IsAvailable() to confirm this loading.
+		*/
+		FileImage(const char* path,bool shortable);
+
+		//! load a file 
+		/*!	@param path  target file
+			@param shortable  allow incompleted load
+			@return  instance pointer (or NULL)
+		*/
+		static FileImage* Load(const char* path,bool shortable);
+
+		//! unload the file image. 
+		inline void Unload(){
+			yges_unload(&mpLoaded);
+		}
+
+		//! check available 
+		inline bool IsAvailable() const{return !!mpLoaded;}
+		//! file size 
+		inline size_t GetFileSize() const{return mpLoaded?mpLoaded->filesize:0;}
+		//! read size (may short from file size) 
+		inline size_t GetReadSize() const{return mpLoaded?mpLoaded->readsize:0;}
+
+		//! begin side of the data 
+		template <typename T>
+		inline const T* GetBegin() const{return reinterpret_cast<const T*>(mpLoaded?yges_loaded_bgn(mpLoaded):NULL);}
+		//! end side of the data 
+		template <typename T>
+		inline const T* GetEnd() const{return reinterpret_cast<const T*>(mpLoaded?yges_loaded_end(mpLoaded):NULL);}
+
+		protected:
+		FileImage(YgEsLoaded* loaded);
+
+		private:
+		YgEsLoaded* mpLoaded;
+	};
+
+} // namespace yges
+
+#endif // YGES_QUICK_LOADER_HPP__

--- a/api/file/quick_loader_pp.cpp
+++ b/api/file/quick_loader_pp.cpp
@@ -1,0 +1,36 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "./quick_loader.hpp"
+
+namespace yges{
+
+	/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+	FileImage::~FileImage(){
+
+		Unload();
+	}
+
+	/* ------------------------------------------------------------------- */
+	FileImage::FileImage(YgEsLoaded* loaded){
+
+		mpLoaded=loaded;
+	}
+
+	/* ------------------------------------------------------------------- */
+	FileImage::FileImage(const char* path,bool shortable){
+
+		mpLoaded=yges_load(path,shortable);
+	}
+
+	/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+	FileImage* FileImage::Load(const char* path,bool shortable){
+
+		YgEsLoaded* img=yges_load(path,shortable);
+		if(!img)return NULL;
+		return new FileImage(img);
+	}
+
+} // namespace yges

--- a/test/scn/Makefile
+++ b/test/scn/Makefile
@@ -6,7 +6,8 @@ AR            = ar
 
 TARGET = \
 	system/emergency.exe system/emergency_pp.exe system/nullproof.exe \
-	memory/safe_alloc.exe memory/memory_emergency.exe
+	memory/safe_alloc.exe memory/memory_emergency.exe \
+	file/quick_loader.exe file/quick_loader_pp.exe
 
 all: $(TARGET)
 

--- a/test/scn/file/quick_loader.c
+++ b/test/scn/file/quick_loader.c
@@ -1,0 +1,39 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader Test
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "file/quick_loader.h"
+#include <stdio.h>
+#include <string.h>
+
+static int ExitCode_Failure=1;
+
+//! same to test.txt 
+static const char* testext="q2w3e4r5t6y7u8i9o0p-@^[\naqwsderftgyhujikolp;@:\nazsxdcfvgbhnjmk,l.;/:\n";
+
+/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+int main(int argc,char** argv){
+
+	// load a file 
+	YgEsLoaded* file=yges_load("./test.txt",false);
+
+	// check file size 
+	size_t len=strlen(testext);
+	if(len!=file->filesize)return ExitCode_Failure;
+	// check read size 
+	// (may short from file size) 
+	if(len!=file->readsize)return ExitCode_Failure;
+
+	// loaded data auto 0 terminated 
+	if(*(char*)yges_loaded_end(file))return ExitCode_Failure;
+
+	// loaded data referable from yges_loaded_bgn(file) 
+	// and can use as a string directly. 
+	if(strcmp(testext,yges_loaded_bgn(file)))return ExitCode_Failure;
+
+	// unload 
+	yges_unload(&file);
+
+	return 0;
+}

--- a/test/scn/file/quick_loader_pp.cpp
+++ b/test/scn/file/quick_loader_pp.cpp
@@ -1,0 +1,58 @@
+﻿/* † Yggdrasil Essence † */
+/*!	@brief  Quick File Loader Test
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#include "file/quick_loader.hpp"
+#include <stdio.h>
+#include <string.h>
+
+static int ExitCode_Failure=1;
+
+//! same to test.txt 
+static const char* testext="q2w3e4r5t6y7u8i9o0p-@^[\naqwsderftgyhujikolp;@:\nazsxdcfvgbhnjmk,l.;/:\n";
+
+/* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
+int main(int argc,char** argv){
+
+	// load a file. 
+	// it's auto unloading at end of the instance. 
+	yges::FileImage file1("./test.txt",false);
+
+	// check loading correctly. 
+	if(!file1.IsAvailable())return ExitCode_Failure;
+
+	// load a file another way. 
+	// of course, need delete at your wish. 
+	yges::FileImage* file2=yges::FileImage::Load("./test.txt",false);
+
+	// check loading correctly. 
+	// in failed, an instance not created. 
+	if(!file2)return ExitCode_Failure;
+
+	// check file size 
+	size_t len=strlen(testext);
+	if(len!=file1.GetFileSize())return ExitCode_Failure;
+	if(len!=file2->GetFileSize())return ExitCode_Failure;
+	// check read size 
+	// (may short from file size) 
+	if(len!=file1.GetReadSize())return ExitCode_Failure;
+	if(len!=file2->GetReadSize())return ExitCode_Failure;
+
+	// loaded data auto 0 terminated 
+	if(*file1.GetEnd<char>())return ExitCode_Failure;
+	if(*file2->GetEnd<char>())return ExitCode_Failure;
+
+	// loaded data can use as a string directly. 
+	if(strcmp(testext,file1.GetBegin<char>()))return ExitCode_Failure;
+	if(strcmp(testext,file2->GetBegin<char>()))return ExitCode_Failure;
+
+	// must unload 
+	delete file2;
+
+	// can unload immediately. 
+	file1.Unload();
+	if(file1.IsAvailable())return ExitCode_Failure;
+
+	return 0;
+}

--- a/test/scn/file/test.txt
+++ b/test/scn/file/test.txt
@@ -1,0 +1,3 @@
+q2w3e4r5t6y7u8i9o0p-@^[
+aqwsderftgyhujikolp;@:
+azsxdcfvgbhnjmk,l.;/:


### PR DESCRIPTION
close #11

## C版

test/scn/file/quick_loader.c 参照  

- yges_load() でロード
- yges_loaded_bgn() で先頭参照
  - 自動的に0終端されているので、そのまま文字列として利用可
- yges_unload() でアンロード

## C++版

test/scn/file/quick_loader_pp.cpp 参照  

- yges::FileImage がラッパクラスで、C版とほぼ同じ機能  
- コンストラクタでのロード
  - インスタンスは常に生成されるため、ロード成功かは IsAvailable() で要確認
- yges::FileImage::Load() でのロード
  - C版同様、ロード失敗時はNULLで返る
- アンロードはデストラクタで自動的に行われるほか、自前で Unload() 可
