### PR TITLE
EmergencyContext を DontCopy とする

### DIFF
--- a/api/system/dontcopy.hpp
+++ b/api/system/dontcopy.hpp
@@ -1,0 +1,25 @@
+/* † Yggdrasil Essence † */
+/*!	@brief  Don't Copy
+	@author  Copyright © 2024 Yggdrasil Leaves, LLC.
+	@sa  https://github.com/ylllc/yges_c
+*/
+#ifndef YGES_DONTCOPY_HPP__
+#define YGES_DONTCOPY_HPP__
+
+namespace yges{
+
+	class DontCopy{
+		protected:
+		// can construct from only inherited class 
+		inline DontCopy(){}
+
+		private:
+		// inherited class cannot copy 
+		inline DontCopy(const DontCopy& src){}
+		// inherited class cannot substitute 
+		inline const DontCopy& operator=(const DontCopy& src){return *this;}
+	};
+
+} // namespace yges
+
+#endif // YGES_DONTCOPY_HPP__

--- a/api/system/dontcopy.hpp
+++ b/api/system/dontcopy.hpp
@@ -8,6 +8,7 @@
 
 namespace yges{
 
+	//! inherited class is uncopyable 
 	class DontCopy{
 		protected:
 		// can construct from only inherited class 

--- a/api/system/emergency_trap.hpp
+++ b/api/system/emergency_trap.hpp
@@ -7,6 +7,7 @@
 #define YGES_EMERGENCY_TRAP_HPP__
 
 #include "./emergency_trap.h"
+#include "./dontcopy.hpp"
 
 namespace yges{
 
@@ -18,7 +19,7 @@ namespace yges{
 			starting in disabled, 
 			need calling Enable() to enable. @n
 	*/
-	class EmergencyContext{
+	class EmergencyContext: DontCopy{
 		public:
 		virtual ~EmergencyContext();
 		EmergencyContext();


### PR DESCRIPTION
close #36 

コピー禁止対象クラスの継承元に DontCopy を追加するだけ。  
